### PR TITLE
Fixes accidental selection bug on slider buttons in Chrome

### DIFF
--- a/wijmo/jquery.ui.wijslider.js
+++ b/wijmo/jquery.ui.wijslider.js
@@ -195,6 +195,8 @@
         },
 
         _decreBtnMouseDown: function (e) {
+            e.preventDefault();
+            
             var self = e.data;
             var data = { buttonType: "decreButton" };
             self._trigger('buttonmousedown', e, data);
@@ -204,6 +206,8 @@
         },
 
         _increBtnMouseDown: function (e) {
+            e.preventDefault();
+          
             var self = e.data;
             var data = { buttonType: "increButton" };
             self._trigger('buttonmousedown', e, data);


### PR DESCRIPTION
This fixes [Issue No. 3](http://github.com/wijmo/Wijmo-Open/issues/#issue/3) I opened a bit ago relating to an accidental selection of the slider content when you clicked too rapidly on the right or down arrows.
