### PR TITLE
Changed usage of global jQuery variable to local $ variable

### DIFF
--- a/wijmo/jquery.wijmo.wijaccordion.js
+++ b/wijmo/jquery.wijmo.wijaccordion.js
@@ -230,7 +230,7 @@
 			var o = this.options;
 			selector = selector ? selector : o.header;
 			this.headers = this.element.find(selector);
-			this.headers.each(jQuery.proxy(this._initHeader, this));
+			this.headers.each($.proxy(this._initHeader, this));
 		},
 		_initHeader: function (index, elem) {
 			var o = this.options, rightToLeft = this.element.data("rightToLeft"),
@@ -366,7 +366,7 @@
 				animOptions = {
 					toShow: nextContent,
 					toHide: prevContent,
-					complete: jQuery.proxy(function () {
+					complete: $.proxy(function () {
 						prevContent.removeClass("ui-accordion-content-active");
 						nextContent.addClass("ui-accordion-content-active");
 						prevContent.css('display', '');
@@ -433,9 +433,9 @@
 		_bindLiveEvents: function () {
 			this.element.find('.ui-accordion-header')
 			.live(this.options.event + ".wijaccordion",
-									jQuery.proxy(this._onHeaderClick, this))
+									$.proxy(this._onHeaderClick, this))
 			.live("keydown.wijaccordion",
-									jQuery.proxy(this._onHeaderKeyDown, this))
+									$.proxy(this._onHeaderKeyDown, this))
 			.live("mouseenter.wijaccordion",
 							function () { $(this).addClass('ui-state-hover'); })
 			.live("mouseleave.wijaccordion",


### PR DESCRIPTION
In jQuery.proxy calls, use of the global jQuery variable could cause issues if jQuery.noConflict(true) is used on a page using multiple versions of jQuery and the other version doesn't have the proxy method.
