### PR TITLE
Enable splitter to collapse bidirectionally.

### DIFF
--- a/samples/splitter/overview.html
+++ b/samples/splitter/overview.html
@@ -17,8 +17,10 @@
 	<script src="../../wijmo/jquery.wijmo.wijsplitter.js" type="text/javascript"></script>
 	<script id="scriptInit" type="text/javascript">
 		$(document).ready(function () {
-			$("#vsplitter").wijsplitter({ orientation: "vertical" });
-			$("#hsplitter").wijsplitter({ orientation: "horizontal" });
+			$("#vsplitter1").wijsplitter({ orientation: "vertical"});
+			$("#vsplitter2").wijsplitter({ orientation: "vertical", collapsingPanel: "panel2" });
+			$("#hsplitter1").wijsplitter({ orientation: "horizontal" });
+			$("#hsplitter2").wijsplitter({ orientation: "horizontal", collapsingPanel: "panel2" });
 		});
 	</script>
 	<style type="text/css">
@@ -27,7 +29,7 @@
 			height: 210px;
 		}
 		
-		#vsplitter, #hsplitter
+		#vsplitter1, #hsplitter1, #vsplitter2, #hsplitter2
 		{
 			width: 200px;
 			height: 200px;
@@ -50,7 +52,17 @@
 			<div class="splitterContainer">
 				<div class="layout">
 					<h3>Vertical</h3>
-					<div id="vsplitter">
+          <h4>Collapsing Panel: panel1</h4>
+					<div id="vsplitter1">
+						<div>
+							panel1
+						</div>
+						<div>
+							panel2
+						</div>
+					</div>
+          <h4>Collapsing Panel: panel2</h4>
+					<div id="vsplitter2">
 						<div>
 							panel1
 						</div>
@@ -63,7 +75,17 @@
 					&nbsp;</div>
 				<div class="layout">
 					<h3>Horizontal</h3>
-					<div id="hsplitter">
+          <h4>Collapsing Panel: panel1</h4>
+					<div id="hsplitter1">
+						<div>
+							panel1
+						</div>
+						<div>
+							panel2
+						</div>
+					</div>
+          <h4>Collapsing Panel: panel2</h4>
+					<div id="hsplitter2">
 						<div>
 							panel1
 						</div>

--- a/themes/wijmo/jquery.wijmo.wijsplitter.css
+++ b/themes/wijmo/jquery.wijmo.wijsplitter.css
@@ -52,7 +52,7 @@
     z-index: 999;
 }
 
-.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-expanded
+.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-panel1-expanded
 {
     border-right: medium none;
     overflow: hidden;
@@ -62,12 +62,12 @@
     z-index: 999;
 }
 
-.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-expanded .ui-icon
+.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-panel1-expanded .ui-icon
 {
     margin-left: -6px;
 }
 
-.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-collapsed
+.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-panel1-collapsed
 {
     border-left: medium none;
     overflow: hidden;
@@ -77,7 +77,37 @@
     z-index: 999;
 }
 
-.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-collapsed .ui-icon
+.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-panel1-collapsed .ui-icon
+{
+    margin-left: -6px;
+}
+
+.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-panel2-expanded
+{
+    border-right: medium none;
+    overflow: hidden;
+    padding: 12px 0;
+    right: -8px;
+    width: 6px;
+    z-index: 999;
+}
+
+.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-panel2-expanded .ui-icon
+{
+    margin-left: -6px;
+}
+
+.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-panel2-collapsed
+{
+    border-left: medium none;
+    overflow: hidden;
+    padding: 12px 0;
+    left: -8px;
+    width: 6px;
+    z-index: 999;
+}
+
+.wijmo-wijsplitter-vertical .wijmo-wijsplitter-v-panel2-collapsed .ui-icon
 {
     margin-left: -6px;
 }
@@ -148,7 +178,7 @@
 }
 
 
-.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-expanded
+.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-panel1-expanded
 {
     border-bottom: none;
     height: 8px;
@@ -158,12 +188,12 @@
     z-index: 999;
 }
 
-.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-expanded .ui-icon
+.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-panel1-expanded .ui-icon
 {
     margin-top: -4px;
 }
 
-.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-collapsed
+.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-panel1-collapsed
 {
     border-top: none;
     height: 8px;
@@ -173,7 +203,37 @@
     z-index: 999;
 }
 
-.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-collapsed .ui-icon
+.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-panel1-collapsed .ui-icon
+{
+    margin-top: -4px;
+}
+
+.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-panel2-expanded
+{
+    border-bottom: none;
+    height: 8px;
+    overflow: hidden;
+    padding: 0 10px;
+    bottom: -10px;
+    z-index: 999;
+}
+
+.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-panel2-expanded .ui-icon
+{
+    margin-top: -4px;
+}
+
+.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-panel2-collapsed
+{
+    border-top: none;
+    height: 8px;
+    overflow: hidden;
+    padding: 0 10px;
+    top: -10px;
+    z-index: 999;
+}
+
+.wijmo-wijsplitter-horizontal .wijmo-wijsplitter-h-panel2-collapsed .ui-icon
 {
     margin-top: -4px;
 }

--- a/wijmo/jquery.wijmo.wijsplitter.js
+++ b/wijmo/jquery.wijmo.wijsplitter.js
@@ -29,10 +29,16 @@
 		hSplitterCssPrefix = splitterCssPrefix + "h-",
 		vSplitterCssPrefix = splitterCssPrefix + "v-",
 		contentCssSuffix = "-content",
-		pnl1Css = "panel1",
-		pnl2Css = "panel2",
-		pnl1ContentCss = pnl1Css + contentCssSuffix,
-		pnl2ContentCss = pnl2Css + contentCssSuffix,
+		panelCss = {
+			panel1: {
+				n: "panel1",
+				content: "panel1" + contentCssSuffix
+			},
+			panel2: {
+				n: "panel2",
+				content: "panel2" + contentCssSuffix
+			}
+		},
 		barCss = "bar",
 		expanderCss = "expander",
 		widgetHeaderCss = "ui-widget-header",
@@ -244,7 +250,12 @@
 				/// Type: String.
 				///	</summary>
 				scrollBars: "auto"
-			}
+			},
+			/// <summary>
+			/// Species the panel which is to be collapsed by the splitter
+			///  button
+			/// </summary>
+			collapsingPanel: 'panel1'
 		},
 
 		_setOption: function (key, value) {
@@ -271,6 +282,8 @@
 
 			if (oldValue !== value) {
 				if (key === "orientation") {
+					self.refresh();
+				} else if (key === "collapsingPanel") {
 					self.refresh();
 				} else if (key === "fullSplit") {
 					self.refresh(true, false);
@@ -404,7 +417,7 @@
 			/// </param>
 			var self = this,
 				fields = self._fields,
-				panel1 = fields.panel1;
+				o = self.options;
 
 			if (fields._isResizing) {
 				return;
@@ -417,8 +430,8 @@
 			self._updateElements();
 
 			if (size || size === undefined) {
-				if (panel1 && panel1.is(":ui-resizable")) {
-					panel1.resizable('destroy');
+				if (fields.panel1 && fields.panel1.n.is(":ui-resizable")) {
+					fields.panel1.n.resizable('destroy');
 				}
 
 				self._initResizer();
@@ -430,11 +443,10 @@
 				element = self.element,
 				o = self.options,
 				fields = self._fields,
-				wrapper, pnl1, pnl2, pnl1Content, pnl2Content,
-				bar, expander, icon;
+				wrapper, bar, expander, icon,
+				pnl1 = { n: null, content: element.find(">div:eq(0)")},
+				pnl2 = { n: null, content: element.find(">div:eq(1)")};
 
-			pnl1Content = element.find(">div:eq(0)");
-			pnl2Content = element.find(">div:eq(1)");
 			fields.originalStyle = element.attr("style");
 			fields.originalContent = element.html();
 
@@ -442,14 +454,14 @@
 			wrapper = $("<div></div>").appendTo(element);
 
 			//create panel1
-			pnl1 = $("<div></div>").appendTo(wrapper);
+			pnl1.n = $("<div></div>").appendTo(wrapper);
 
 			//create panel1 content if needed.
-			if (pnl1Content.length === 0) {
-				pnl1Content = $("<div></div>");
+			if (pnl1.content.length === 0) {
+				pnl1.content = $("<div></div>");
 			}
 
-			pnl1Content.appendTo(pnl1);
+			pnl1.content.appendTo(pnl1.n);
 
 			//create bar.
 			bar = $("<div></div>").appendTo(wrapper);
@@ -466,20 +478,18 @@
 			icon = $("<span></span>").appendTo(expander);
 
 			//create panel2
-			pnl2 = $("<div></div>").appendTo(wrapper);
+			pnl2.n = $("<div></div>").appendTo(wrapper);
 
 			//create panel2 content if needed.
-			if (pnl2Content.length === 0) {
-				pnl2Content = $("<div></div>");
+			if (pnl2.content.length === 0) {
+				pnl2.content = $("<div></div>");
 			}
 
-			pnl2Content.appendTo(pnl2);
+			pnl2.content.appendTo(pnl2.n);
 
 			fields.wrapper = wrapper;
 			fields.panel1 = pnl1;
-			fields.pnl1Content = pnl1Content;
 			fields.panel2 = pnl2;
-			fields.pnl2Content = pnl2Content;
 			fields.bar = bar;
 			fields.expander = expander;
 			fields.icon = icon;
@@ -491,11 +501,9 @@
 				o = self.options,
 				isVertical = o.orientation === "vertical",
 				fields = self._fields,
+				collapsingPanel = o.collapsingPanel,
+				otherPanel = o.collapsingPanel === 'panel1' ? 'panel2': 'panel1',
 				wrapper = fields.wrapper,
-				pnl1 = fields.panel1,
-				pnl2 = fields.panel2,
-				pnl1Content = fields.pnl1Content,
-				pnl2Content = fields.pnl2Content,
 				bar = fields.bar,
 				expander = fields.expander,
 				icon = fields.icon;
@@ -517,17 +525,19 @@
 			wrapper.attr("class", wrapperCss);
 
 			//add class to panel1
-			pnl1.removeClass(vSplitterCssPrefix + pnl1Css + " " +
-					hSplitterCssPrefix + pnl1Css)
+			fields[collapsingPanel].n.removeClass(
+					vSplitterCssPrefix + panelCss[collapsingPanel].n + " " +
+					hSplitterCssPrefix + panelCss[collapsingPanel].n)
 				.addClass((isVertical ? vSplitterCssPrefix :
-					hSplitterCssPrefix) + pnl1Css);
+					hSplitterCssPrefix) + panelCss[collapsingPanel].n);
 
 			//add class to panel1 content.
-			pnl1Content.removeClass(vSplitterCssPrefix + pnl1ContentCss +
-				" " + hSplitterCssPrefix + pnl1ContentCss +
-				" " + widgetContentCss)
+			fields[collapsingPanel].content.removeClass(
+					vSplitterCssPrefix + panelCss[collapsingPanel].content + " " +
+					hSplitterCssPrefix + panelCss[collapsingPanel].content + " " +
+					widgetContentCss)
 				.addClass((isVertical ? vSplitterCssPrefix :
-					hSplitterCssPrefix) + pnl1ContentCss + " " + widgetContentCss);
+					hSplitterCssPrefix) + panelCss[collapsingPanel].content + " " + widgetContentCss);
 
 			//add class to bar.
 			bar.attr("class", (isVertical ? vSplitterCssPrefix :
@@ -545,17 +555,20 @@
 					(isVertical ? "w" : "n"));
 
 			//add class to panel2
-			pnl2.removeClass(vSplitterCssPrefix + pnl2Css + " " +
-					hSplitterCssPrefix + pnl2Css)
+			fields[otherPanel].n.removeClass(
+					vSplitterCssPrefix + panelCss[otherPanel].n + " " +
+					hSplitterCssPrefix + panelCss[otherPanel].n)
 				.addClass((isVertical ? vSplitterCssPrefix :
-					hSplitterCssPrefix) + pnl2Css);
+					hSplitterCssPrefix) + panelCss[otherPanel].n);
 
 			//add class to panel2 content.
-			pnl2Content.removeClass(vSplitterCssPrefix + pnl1ContentCss +
-				" " + hSplitterCssPrefix + pnl1ContentCss +
-				" " + widgetContentCss)
+			fields[otherPanel].content.removeClass(
+					vSplitterCssPrefix + panelCss[otherPanel].content + " " +
+					hSplitterCssPrefix + panelCss[otherPanel].content + " " +
+					widgetContentCss)
 				.addClass((isVertical ? vSplitterCssPrefix :
-					hSplitterCssPrefix) + pnl2ContentCss + " " + widgetContentCss);
+					hSplitterCssPrefix) + panelCss[otherPanel].content + " " +
+					widgetContentCss);
 
 			// if panel1.collapsed = true, then we need update 
 			// the expander icon's css.
@@ -570,19 +583,17 @@
 				expander = fields.expander,
 				icon = fields.icon,
 				isVertical = o.orientation === "vertical",
+				panel2IsCollapsing = o.collapsingPanel !== "panel1",
 				cssPrefix = isVertical ? vSplitterCssPrefix : hSplitterCssPrefix,
-				collapsedExpCorner1Css = isVertical ? "tr" : "bl",
-				collapsedExpCorner2Css = "br",
-				collapsedIconCss = isVertical ? "e" : "s",
-				expandedExpCorner1Css = isVertical ? "bl" : "tr",
-				expandedExpCorner2Css = "tl",
-				expandedIconCss = isVertical ? "w" : "n";
+				collapsedExpCorner1Css = ["bl", "tr", "tr", "bl"][isVertical * 2+ panel2IsCollapsing],
+				collapsedExpCorner2Css = ["br", "tl"][+panel2IsCollapsing],
+				collapsedIconCss = ["s", "n", "e", "w"][isVertical * 2 + panel2IsCollapsing],
+				expandedExpCorner1Css = ["tr", "bl", "bl", "tr"][isVertical * 2 + panel2IsCollapsing],
+				expandedExpCorner2Css = ["tl", "br"][+panel2IsCollapsing],
+				expandedIconCss = ["n", "s", "w", "e"][isVertical * 2 + panel2IsCollapsing];
 
-			//			element.removeClass(cssPrefix + expandedCss +
-			//				" " + cssPrefix + collapsedCss);
-
-			expander.removeClass(cssPrefix + expandedCss +
-				" " + cssPrefix + collapsedCss +
+			expander.removeClass(cssPrefix + o.collapsingPanel + "-" + expandedCss +
+				" " + cssPrefix + o.collapsingPanel + "-" + collapsedCss +
 				" " + cornerCssPrefix + collapsedExpCorner1Css +
 				" " + cornerCssPrefix + collapsedExpCorner2Css +
 				" " + cornerCssPrefix + expandedExpCorner1Css +
@@ -591,17 +602,17 @@
 			icon.removeClass(arrowCssPrefix + collapsedIconCss +
 				" " + arrowCssPrefix + expandedIconCss);
 
-			if (o.panel1.collapsed) {
+			if (o.panel1.collapsed || o.panel2.collapsed) {
 				//element.addClass(cssPrefix + collapsedCss);
 				expander.addClass(cornerCssPrefix + collapsedExpCorner1Css +
 					" " + cornerCssPrefix + collapsedExpCorner2Css +
-					" " + cssPrefix + collapsedCss);
+					" " + cssPrefix + o.collapsingPanel + "-" + collapsedCss);
 				icon.addClass(arrowCssPrefix + collapsedIconCss);
 			} else {
 				//element.addClass(cssPrefix + expandedCss);
 				expander.addClass(cornerCssPrefix + expandedExpCorner1Css +
 					" " + cornerCssPrefix + expandedExpCorner2Css +
-					" " + cssPrefix + expandedCss);
+					" " + cssPrefix + o.collapsingPanel + "-" + expandedCss);
 				icon.addClass(arrowCssPrefix + expandedIconCss);
 			}
 		},
@@ -611,12 +622,11 @@
 				element = self.element,
 				o = self.options,
 				distance = o.splitterDistance,
-				fields = self._fields,
+				collapsingPanel = o.collapsingPanel,
+				otherPanel = o.collapsingPanel === 'panel1' ? 'panel2': 'panel1', fields = self._fields,
 				wrapper = fields.wrapper,
 				pnl1 = fields.panel1,
-				pnl1Content = fields.pnl1Content,
 				pnl2 = fields.panel2,
-				pnl2Content = fields.pnl2Content,
 				bar = fields.bar,
 				expander = fields.expander,
 				width = element.width(),
@@ -635,26 +645,49 @@
 
 				wrapper.width(width * 2);
 
-				if (o.panel2.collapsed && !o.panel1.collapsed) {
-					distance = width - barW;
-				}
-
 				if (o.panel1.collapsed) {
-					//element.addClass(vSplitterCssPrefix + collapsedCss);
-					expander.addClass(vSplitterCssPrefix + collapsedCss);
-					pnl1.css("display", "none");
+					if (collapsingPanel === "panel1") {
+						expander.addClass(vSplitterCssPrefix + "panel1" + "-" + collapsedCss);
+					}
+					fields.panel1.n.css("display", "none");
 					distance = 0;
 				} else {
-					//element.addClass(vSplitterCssPrefix + expandedCss);
-					expander.addClass(vSplitterCssPrefix + expandedCss);
-					pnl1.css("display", "");
+					if (collapsingPanel === "panel1") {
+						expander.addClass(vSplitterCssPrefix + "panel1" + "-" + expandedCss);
+					}
+					fields.panel1.n.css("display", "");
 				}
 
-				pnl1.height(height).width(distance);
-				pnl1Content.outerHeight(height, true);
+				if (o.panel2.collapsed) {
+					if (collapsingPanel === "panel2") {
+						expander.addClass(vSplitterCssPrefix + "panel2" + "-" + collapsedCss); 
+					}
+					fields.panel2.n.css("display", "none");
+					distance = (collapsingPanel === "panel1") ?
+							width - barW: width;
+				} else {
+					if (collapsingPanel === "panel2") {
+						expander.addClass(vSplitterCssPrefix + "panel2" + "-" + expandedCss);
+					}
+					fields.panel2.n.css("display", "");
+				}
+
+				if (!o.panel1.collapsed && !o.panel2.collapsed) {
+					expander.addClass(vSplitterCssPrefix + o.collapsingPanel + "-" + expandedCss);
+				}
+
+				if (collapsingPanel === "panel1") {
+					fields.panel1.n.height(height).width(distance);
+					fields.panel2.n.height(height).width(width - distance - barW);
+				} else {
+					fields.panel1.n.height(height).width(distance - barW);
+					fields.panel2.n.height(height).width(width - distance);
+					fields.panel2.content.width(width - distance);
+				}
+
+				fields.panel1.content.outerHeight(height, true);
 				bar.outerHeight(height, true);
-				pnl2.height(height).width(width - distance - barW);
-				pnl2Content.outerHeight(height, true);
+				fields.panel2.content.outerHeight(height, true);
 
 				expander.css("cursor", "pointer")
 					.css("top", height / 2 - expander.outerHeight(true) / 2);
@@ -665,27 +698,44 @@
 					distance = height - barH;
 				}
 
-				if (o.panel2.collapsed && !o.panel1.collapsed) {
-					distance = height - barH;
-				}
-
-				pnl1Content.outerHeight(distance, true);
-
 				if (o.panel1.collapsed) {
-					//element.addClass(hSplitterCssPrefix + collapsedCss);
-					expander.addClass(hSplitterCssPrefix + collapsedCss);
-					pnl1.css("display", "none");
+					if (collapsingPanel === "panel1") {
+						expander.addClass(hSplitterCssPrefix + "panel1" + "-" + collapsedCss);
+					}
+					fields.panel1.n.css("display", "none");
 					distance = 0;
 				} else {
-					//element.addClass(hSplitterCssPrefix + expandedCss);
-					expander.addClass(hSplitterCssPrefix + expandedCss);
-					pnl1.css("display", "");
+					if (collapsingPanel === "panel1") {
+						expander.addClass(hSplitterCssPrefix + "panel1" + "-" + expandedCss);
+					}
+					fields.panel1.n.css("display", "");
 				}
 
-				pnl2Content.outerHeight(height - distance - barH, true);
+				if (o.panel2.collapsed) {
+					if (collapsingPanel === "panel2") {
+						expander.addClass(hSplitterCssPrefix + "panel2" + "-" + collapsedCss);
+					}
+					fields.panel2.n.css("display", "none");
+					distance = (collapsingPanel === "panel1") ?
+							height - barH: height;
+				} else {
+					if (collapsingPanel === "panel2") {
+						expander.addClass(hSplitterCssPrefix + "panel2" + "-" + expandedCss);
+					}
+					fields.panel2.n.css("display", "");
+				}
 
-				pnl1.width(width).height(distance);
-				pnl2.width(width).height(height - distance - barH);
+				if (collapsingPanel === "panel1") {
+					fields.panel1.n.width(width).height(distance);
+					fields.panel2.n.width(width).height(height - distance - barH);
+					fields.panel1.content.outerHeight(distance, true);
+					fields.panel2.content.outerHeight(height - distance - barH, true);
+				} else {
+					fields.panel1.n.width(width).height(distance - barH);
+					fields.panel2.n.width(width).height(height - distance);
+					fields.panel1.content.outerHeight(distance - barH, true);
+					fields.panel2.content.outerHeight(height - distance, true);
+				}
 
 				expander.css("cursor", "pointer")
 					.css("left", width / 2 - expander.outerWidth(true) / 2);
@@ -706,30 +756,38 @@
 		_setPanel1Collapsed: function (collapsed, e) {
 			var self = this,
 				o = self.options,
-				oldCollapsed = o.panel1.collapsed;
+				oldCollapsed = o.panel1.collapsed,
+				resizableHandle = $(".ui-resizable-handle", self.element);
 
 			if (oldCollapsed === collapsed) {
 				return;
 			}
 
-			if (!self._trigger(oldCollapsed ? "expand" : "collapse", e, null)) {
-				return;
+			if (o.collapsingPanel === 'panel1') {
+				if (!self._trigger(oldCollapsed ? "expand" : "collapse", e, null)) {
+					return;
+				}
 			}
 
 			o.panel1.collapsed = collapsed;
 
 			if (collapsed) {
 				o.panel2.collapsed = false;
+				if (o.collapsingPanel === 'panel2')
+					resizableHandle.hide();
 			} else {
-				$(".ui-resizable-handle", self.element).show();
+				resizableHandle.show();
 			}
 
 			self._updateElements();
 			self._updateExpanderCss();
-			self._trigger(collapsed ? "collapsed" : "expanded", e, null);
+
+			if (o.collapsingPanel === 'panel1') {
+				self._trigger(collapsed ? "collapsed" : "expanded", e, null);
+			}
 		},
 
-		_setPanel2Collapsed: function (collapsed) {
+		_setPanel2Collapsed: function (collapsed, e) {
 			var self = this,
 				o = self.options,
 				oldCollapsed = o.panel2.collapsed,
@@ -739,16 +797,28 @@
 				return;
 			}
 
+			if (o.collapsingPanel === 'panel2') {
+				if (!self._trigger(oldCollapsed ? "expand" : "collapse", e, null)) {
+					return;
+				}
+			}
+
 			o.panel2.collapsed = collapsed;
 
 			if (collapsed) {
 				o.panel1.collapsed = false;
-				resizableHandle.hide();
+				if (o.collapsingPanel === 'panel1')
+					resizableHandle.hide();
 			} else {
 				resizableHandle.show();
 			}
 
 			self._updateElements();
+			self._updateExpanderCss();
+
+			if (o.collapsingPanel === 'panel2') {
+				self._trigger(collapsed ? "collapsed" : "expanded", e, null);
+			}
 		},
 
 		_bindEvents: function () {
@@ -757,7 +827,6 @@
 				fields = self._fields,
 				bar = fields.bar,
 				expander = fields.expander,
-				panel1 = fields.panel1,
 				widgetName = self.widgetName;
 
 			expander.bind("mouseover." + widgetName, function (e) {
@@ -785,12 +854,11 @@
 
 				expander.removeClass(stateActiveCss);
 
-				if (o.panel2.collapsed) {
-					self._setPanel2Collapsed(!o.panel2.collapsed);
-					return;
+				if (o.collapsingPanel === 'panel1') {
+					self._setPanel1Collapsed(!o.panel1.collapsed, e);
+				} else {
+					self._setPanel2Collapsed(!o.panel2.collapsed, e);
 				}
-
-				self._setPanel1Collapsed(!o.panel1.collapsed, e);
 			});
 
 			bar.bind("mouseover." + widgetName, function (e) {
@@ -806,7 +874,8 @@
 				bar.removeClass(stateHoverCss);
 			});
 
-			panel1.bind("animating." + widgetName, function (e) {
+			fields.panel1.n
+			.bind("animating." + widgetName, function (e) {
 				if (o.disabled) {
 					return;
 				}
@@ -853,7 +922,8 @@
 				o = self.options,
 				fields = self._fields,
 				bar = fields.bar,
-				panel1 = fields.panel1,
+				collapsingPanel = o.collapsingPanel,
+				otherPanel = o.collapsingPanel === 'panel1' ? 'panel2': 'panel1',
 				resizeSettings = o.resizeSettings,
 				animation = resizeSettings.animationOptions,
 				duration = animation.disabled ? 0 : animation.duration,
@@ -864,14 +934,14 @@
 
 			if (o.orientation === "vertical") {
 				barW = bar.outerWidth(true);
-				maxW = width - barW - o.panel2.minSize;
-				minW = o.panel1.minSize;
+				maxW = width - barW - o[otherPanel].minSize;
+				minW = o[collapsingPanel].minSize;
 
 				if (minW < 2) {
 					minW = 2;
 				}
 
-				panel1.resizable({
+				fields.panel1.n.resizable({
 					wijanimate: true,
 					minWidth: minW,
 					maxWidth: maxW,
@@ -889,14 +959,14 @@
 				});
 			} else {
 				barH = bar.outerHeight(true);
-				maxH = height - barH - o.panel2.minSize;
-				minH = o.panel1.minSize;
+				maxH = height - barH - o[otherPanel].minSize;
+				minH = o[collapsingPanel].minSize;
 
 				if (minH < 2) {
 					minH = 2;
 				}
 
-				panel1.resizable({
+				fields.panel1.n.resizable({
 					wijanimate: true,
 					minHeight: minH,
 					maxHeight: maxH,
@@ -915,7 +985,7 @@
 			}
 
 			resizableHandle = $(".ui-resizable-handle", element);
-			if (o.panel2.collapsed) {
+			if (o[otherPanel].collapsed) {
 				resizableHandle.hide();
 			} else {
 				resizableHandle.show();
@@ -931,9 +1001,9 @@
 		_adjustLayout: function (self) {
 			var o = self.options,
 				fields = self._fields,
-				panel1 = fields.panel1,
 				distance = o.orientation === "vertical" ?
-					panel1.width() : panel1.height();
+					fields.panel1.n.width():
+					fields.panel1.n.height();
 
 			if (o.splitterDistance === distance) {
 				return;
@@ -949,17 +1019,17 @@
 				o = self.options,
 				pnlScrollBars = [o.panel1.scrollBars, o.panel2.scrollBars];
 
-			$.each([fields.pnl1Content, fields.pnl2Content], function (idx, pnlContent) {
+			$.each(fields, function (idx, panelElems) {
 				if (pnlScrollBars[idx] === "auto") {
-					pnlContent.css("overflow", "auto");
+					panelElems.content.css("overflow", "auto");
 				} else if (pnlScrollBars[idx] === "both") {
-					pnlContent.css("overflow", "scroll");
+					panelElems.content.css("overflow", "scroll");
 				} else if (pnlScrollBars[idx] === "none") {
-					pnlContent.css("overflow", "hidden");
+					panelElems.content.css("overflow", "hidden");
 				} else if (pnlScrollBars[idx] === "horizontal") {
-					pnlContent.css("overflow-x", "scroll").css("overflow-y", "hidden");
+					panelElems.content.css("overflow-x", "scroll").css("overflow-y", "hidden");
 				} else if (pnlScrollBars[idx] === "vertical") {
-					pnlContent.css("overflow-x", "hidden").css("overflow-y", "scroll");
+					panelElems.content.css("overflow-x", "hidden").css("overflow-y", "scroll");
 				}
 			});
 		}


### PR DESCRIPTION
This change enables wijmo splitter to collapse either panel instead of the first panel only. The following new option is introduced for specifying which panel to collapse.

collapsingPanel: [panel1|panel2]
